### PR TITLE
Fix double registering for VOID_BLOSSOM_STRUCTURE_TYPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix double registering for VOID_BLOSSOM_STRUCTURE_TYPE (Fix NeoForge .238+ crash)
+- Fix double registering for VOID_BLOSSOM_STRUCTURE_TYPE (Fix NeoForge .238+ crash). Thanks [jsaperr](https://github.com/jsaperr).
 
 ## [1.3.2] - 2025-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-07-16
+
+### Fixed
+
+- Fix double registering for VOID_BLOSSOM_STRUCTURE_TYPE (Fix NeoForge .238+ crash)
+
 ## [1.3.2] - 2025-01-23
 
 ### Fixed

--- a/Common/src/main/java/com/cerbon/bosses_of_mass_destruction/structure/BMDStructures.java
+++ b/Common/src/main/java/com/cerbon/bosses_of_mass_destruction/structure/BMDStructures.java
@@ -25,7 +25,7 @@ public class BMDStructures {
     public static final StructureRegister GAUNTLET_STRUCTURE_REGISTRY = new StructureRegister(ResourceLocation.fromNamespaceAndPath(BMDConstants.MOD_ID, "gauntlet_arena"));
     public static final StructureRegister LICH_STRUCTURE_REGISTRY = new StructureRegister(ResourceLocation.fromNamespaceAndPath(BMDConstants.MOD_ID, "lich_tower"));
 
-    public static final RegistryEntry<StructureType<VoidBlossomArenaStructureFeature>> VOID_BLOSSOM_STRUCTURE_TYPE = STRUCTURE_TYPES.register("void_blossom", () -> Registry.register(BuiltInRegistries.STRUCTURE_TYPE, ResourceLocation.fromNamespaceAndPath(BMDConstants.MOD_ID, "void_blossom"), () -> VoidBlossomArenaStructureFeature.CODEC));
+    public static final RegistryEntry<StructureType<VoidBlossomArenaStructureFeature>> VOID_BLOSSOM_STRUCTURE_TYPE = STRUCTURE_TYPES.register("void_blossom", () -> (StructureType<VoidBlossomArenaStructureFeature>) () -> VoidBlossomArenaStructureFeature.CODEC);
     public static final RegistryEntry<StructurePieceType> VOID_BLOSSOM_CAVERN_PIECE = STRUCTURE_PIECES.register("void_blossom_piece", () -> StructureFactories.VOID_BLOSSOM);
 
     public static final TagKey<Structure> SOUL_STAR_STRUCTURE_KEY = TagKey.create(Registries.STRUCTURE, ResourceLocation.fromNamespaceAndPath(BMDConstants.MOD_ID, "soul_star_target"));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-mod_version=1.3.2
+mod_version=1.3.3
 maven_group=com.cerbon.bosses_of_mass_destruction
 
 # Minecraft


### PR DESCRIPTION
Fixes #27 

VOID_BLOSSOM_STRUCTURE_TYPE registered void_blossom twice: once via STRUCTURE_TYPES.register(...), and again through a manual Registry.register(...) call. It's always double registered, but older NeoForge didn't catch it (neoforged/NeoForge#3285) which has been since been fixed, so it gets detected and crashed. 

Fix: remove the manual Registry.register(...) call.

Tested building against master (1.3.2) on NeoForge 21.1.238 / MC 1.21.1 and boots clean.